### PR TITLE
feat: sequential scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI check
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
 jobs:
   lint:

--- a/denon.config.ts
+++ b/denon.config.ts
@@ -1,15 +1,22 @@
-import { DenonConfig } from "https://deno.land/x/denon/mod.ts";
+import { DenonConfig } from "./mod.ts";
 
 const config: DenonConfig = {
   scripts: {
-    test: {
-      cmd: "deno test",
-      desc: "run denon test",
-      allow: [
-        "read",
-      ],
-      unstable: true,
-    },
+    test: [
+      {
+        cmd: "deno fmt",
+        desc: "run denon format",
+      },
+      {
+        cmd: "deno test",
+        desc: "run denon format",
+        allow: [
+          "all",
+        ],
+        unstable: true,
+        watch: false,
+      },
+    ],
   },
 };
 

--- a/denon.config.ts
+++ b/denon.config.ts
@@ -5,18 +5,21 @@ const config: DenonConfig = {
     test: [
       {
         cmd: "deno fmt",
-        desc: "run denon format",
+        desc: "format code",
+      },
+      {
+        cmd: "deno lint --unstable",
+        desc: "lint code",
       },
       {
         cmd: "deno test",
-        desc: "run denon format",
-        allow: [
-          "all",
-        ],
-        unstable: true,
-        watch: false,
+        desc: "test code",
+        allow: "all",
       },
     ],
+  },
+  logger: {
+    debug: true,
   },
 };
 

--- a/denon.config.ts
+++ b/denon.config.ts
@@ -8,18 +8,23 @@ const config: DenonConfig = {
         desc: "format code",
       },
       {
-        cmd: "deno lint --unstable",
+        cmd: "deno lint",
         desc: "lint code",
+        unstable: true,
       },
       {
         cmd: "deno test",
         desc: "test code",
         allow: "all",
+        unstable: true,
       },
     ],
   },
   logger: {
-    debug: true,
+    debug: false,
+  },
+  watcher: {
+    legacy: true,
   },
 };
 

--- a/denon.ts
+++ b/denon.ts
@@ -127,7 +127,7 @@ if (import.meta.main) {
   }
 
   // create configuration file.
-  // TODO: should be made interactive.
+  // TODO(@qu4k): should be made interactive.
   if (args.init) {
     await initializeConfig(args.init);
     Deno.exit(0);
@@ -151,7 +151,7 @@ if (import.meta.main) {
     log.info(`watching extensions: ${config.watcher.exts.join(",")}`);
   }
 
-  // TODO(qu4k): events
+  // TODO(@qu4k): events
   for await (let event of denon.run(script)) {
     if (event.type === "reload") {
       if (

--- a/denon.ts
+++ b/denon.ts
@@ -16,8 +16,8 @@ import { readConfig, CompleteDenonConfig, reConfig } from "./src/config.ts";
 import { parseArgs } from "./src/args.ts";
 import log from "./src/log.ts";
 
-export const VERSION = "v2.2.1";
-export const BRANCH = "master";
+export const VERSION = "v2.3.0";
+export const BRANCH = "dev";
 
 const logger = log.prefix("main");
 

--- a/deps.ts
+++ b/deps.ts
@@ -15,7 +15,9 @@ export {
   reset,
   bold,
   blue,
+  green,
   yellow,
+  italic,
   red,
   gray,
 } from "https://deno.land/std@0.61.0/fmt/colors.ts";

--- a/examples/denon.config.ts
+++ b/examples/denon.config.ts
@@ -6,17 +6,12 @@ const config: DenonConfig = {
     run: {
       cmd: "simple.ts",
       desc: "Run main app",
-      allow: [
-        "env",
-      ],
+      allow: ["env"],
     },
     oak: {
       cmd: "oak.ts",
       desc: "Run oak instance",
-      allow: [
-        "env",
-        "net",
-      ],
+      allow: ["env", "net"],
       env: {
         PORT: "9001",
       },

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -22,6 +22,6 @@ while (i > 0) {
   console.log(Deno.pid, red(`Execution #${i}!`));
 
   if (--i % 10 === 0) {
-    throw "Oh no.";
+    throw new Error("Oh no.");
   }
 }

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -9,11 +9,7 @@ console.log(
   Deno.env.get("SECRET_ENV_VARIABLE"),
 );
 
-console.log(
-  Deno.pid,
-  green("args:"),
-  Deno.args,
-);
+console.log(Deno.pid, green("args:"), Deno.args);
 
 let i = 50;
 

--- a/schema.json
+++ b/schema.json
@@ -62,6 +62,11 @@
           "type": "boolean",
           "default": false
         },
+        "watch": {
+          "description": "Enable file watching.",
+          "type": "boolean",
+          "default": true
+        },
         "inspect": {
           "description": "Activate inspector on host:port",
           "type": "string",

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,16 +1,10 @@
 // Copyright 2020-present the denosaurs team. All rights reserved. MIT license.
 
-import { reConfig } from "./config.ts";
-
-/**
- * Regex to test if string matches version format
- */
+/** Regex to test if string matches version format */
 const reVersion = /^v?[0-9]+\.[0-9]+\.[0-9]+$/;
 
-/**
- * Map of supported flags that modify
- * `denon` behavior.
- */
+/** Map of supported flags that modify
+ * `denon` behavior. */
 export interface Args {
   help: boolean;
   version: boolean;
@@ -22,10 +16,8 @@ export interface Args {
   cmd: string[];
 }
 
-/**
- * Parse Deno.args into a flag map (`Args`)
- * to be handled by th CLI.
- */
+/** Parse Deno.args into a flag map (`Args`)
+ * to be handled by th CLI. */
 export function parseArgs(args: string[] = Deno.args): Args {
   if (args[0] === "--") {
     args = args.slice(1);
@@ -40,10 +32,7 @@ export function parseArgs(args: string[] = Deno.args): Args {
     cmd: [],
   };
 
-  if (
-    (args.includes("--config") || args.includes("-c")) &&
-    args.length > 1
-  ) {
+  if ((args.includes("--config") || args.includes("-c")) && args.length > 1) {
     flags.config = args[1];
     args = args.slice(2);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-present the denosaurs team. All rights reserved. MIT license.
 
 import {
-  log,
   yellow,
   bold,
   gray,
@@ -11,7 +10,6 @@ import {
   grant,
   exists,
   omelette,
-  red,
 } from "../deps.ts";
 
 import {
@@ -21,10 +19,12 @@ import {
 } from "./config.ts";
 import { Runner } from "./runner.ts";
 import { VERSION } from "../denon.ts";
-import { Watcher } from "./watcher.ts";
 
-/**
- * These are the permissions required for a clean run
+import log from "./log.ts";
+
+const logger = log.prefix("main");
+
+/** These are the permissions required for a clean run
  * of `denon`. If not provided through installation they
  * will be asked on every run by the `grant()` std function.
  *
@@ -35,8 +35,7 @@ import { Watcher } from "./watcher.ts";
  * - *write*, write configuration templates.
  * - *run*, used to run scripts as child processes.
  * - *write*, download configuration templates and import
- * `denon.config.ts` file.
- */
+ * `denon.config.ts` file. */
 export const PERMISSIONS: Deno.PermissionDescriptor[] = [
   { name: "read" },
   { name: "write" },
@@ -44,11 +43,9 @@ export const PERMISSIONS: Deno.PermissionDescriptor[] = [
   { name: "net" },
 ];
 
-/**
- * These permissions are required on specific situations,
+/** These permissions are required on specific situations,
  * `denon` should not be installed with this permissions
- * but you should be granting them when they are required.
- */
+ * but you should be granting them when they are required. */
 export const PERMISSION_OPTIONAL: {
   [key: string]: Deno.PermissionDescriptor[];
 } = {
@@ -60,41 +57,36 @@ export async function grantPermissions(): Promise<void> {
   // @see PERMISSIONS .
   let permissions = await grant([...PERMISSIONS]);
   if (!permissions || permissions.length < PERMISSIONS.length) {
-    log.critical("Required permissions `read` and `run` not granted");
+    logger.critical("Required permissions `read` and `run` not granted");
     Deno.exit(1);
   }
 }
-
-/**
- * Create configuration file in the root of current work directory.
- * // TODO: make it interactive
- */
+/** Create configuration file in the root of current work directory.
+ * // TODO: make it interactive */
 export async function initializeConfig(template: string): Promise<void> {
   let permissions = await grant(PERMISSION_OPTIONAL.initializeConfig);
   if (
     !permissions ||
     permissions.length < PERMISSION_OPTIONAL.initializeConfig.length
   ) {
-    log.critical("Required permissions for this operation not granted");
+    logger.critical("Required permissions for this operation not granted");
     Deno.exit(1);
   }
-  if (!await exists(template)) {
+  if (!(await exists(template))) {
     await writeConfigTemplate(template);
   } else {
-    log.error(`\`${template}\` already exists in root dir`);
+    logger.error(`\`${template}\` already exists in root dir`);
   }
 }
 
-/**
- * Grab a fresh copy of denon
- */
+/** Grab a fresh copy of denon */
 export async function upgrade(version?: string): Promise<void> {
   const url = `https://deno.land/x/denon${
     version ? `@${version}` : ""
   }/denon.ts`;
 
   if (version === VERSION) {
-    log.info(`Version ${version} already installed`);
+    logger.info(`Version ${version} already installed`);
     Deno.exit(0);
   }
 
@@ -103,19 +95,17 @@ export async function upgrade(version?: string): Promise<void> {
     !permissions ||
     permissions.length < PERMISSION_OPTIONAL.upgradeExe.length
   ) {
-    log.critical("Required permissions for this operation not granted");
+    logger.critical("Required permissions for this operation not granted");
     Deno.exit(1);
   }
 
-  log.debug(`Checking if ${url} exists`);
+  logger.debug(`Checking if ${url} exists`);
   if ((await fetch(url)).status !== 200) {
-    log.critical(`Upgrade url ${url} does not exist`);
+    logger.critical(`Upgrade url ${url} does not exist`);
     Deno.exit(1);
   }
 
-  log.info(
-    `Running \`deno install -Af --unstable ${url}\``,
-  );
+  logger.info(`Running \`deno install -Af --unstable ${url}\``);
   await Deno.run({
     cmd: [
       "deno",
@@ -132,9 +122,7 @@ export async function upgrade(version?: string): Promise<void> {
   Deno.exit(0);
 }
 
-/**
- * Generate autocomplete suggestions
- */
+/** Generate autocomplete suggestions */
 export function autocomplete(config: CompleteDenonConfig): void {
   // Write your CLI template.
   const completion = omelette.default(`denon <script>`);
@@ -156,13 +144,11 @@ export function autocomplete(config: CompleteDenonConfig): void {
   completion.init();
 }
 
-/**
- * List all available scripts declared in the config file.
- * // TODO(@qu4k): make it interactive
- */
+/** List all available scripts declared in the config file.
+ * // TODO(@qu4k): make it interactive */
 export function printAvailableScripts(config: CompleteDenonConfig): void {
   if (Object.keys(config.scripts).length) {
-    log.info("available scripts:");
+    logger.info("available scripts:");
     const runner = new Runner(config);
     for (const name of Object.keys(config.scripts)) {
       const script = config.scripts[name];
@@ -178,35 +164,33 @@ export function printAvailableScripts(config: CompleteDenonConfig): void {
         .map((command) => command.cmd.join(" "))
         .join(bold(" && "));
 
-      console.log(
-        gray(`   $ ${commands}`),
-      );
+      console.log(gray(`   $ ${commands}`));
     }
     console.log();
     console.log(
       `You can run scripts with \`${blue("denon")} ${yellow("<script>")}\``,
     );
   } else {
-    log.error("It looks like you don't have any scripts...");
+    logger.error("It looks like you don't have any scripts...");
     const config = getConfigFilename();
     if (config) {
-      log.info(
+      logger.info(
         `You can add scripts to your \`${config}\` file. Check the docs.`,
       );
     } else {
-      log.info(
-        `You can create a config to add scripts to with \`${blue("denon")} ${
-          yellow("--init")
-        }${reset("\`.")}`,
+      logger.info(
+        `You can create a config to add scripts to with \`${
+          blue(
+            "denon",
+          )
+        } ${yellow("--init")}${reset("`.")}`,
       );
     }
   }
 }
 
-/**
- * Help message to be shown if `denon`
- * is run with `--help` flag.
- */
+/** Help message to be shown if `denon`
+ * is run with `--help` flag. */
 export function printHelp(version: string): void {
   setColorEnabled(true);
   console.log(
@@ -215,10 +199,14 @@ Monitor any changes in your Deno application and automatically restart.
 
 Usage:
     ${blue("denon")} ${yellow("<script name>")}     ${
-      gray("-- eg: denon start")
+      gray(
+        "-- eg: denon start",
+      )
     }
     ${blue("denon")} ${yellow("<command>")}         ${
-      gray("-- eg: denon run helloworld.ts")
+      gray(
+        "-- eg: denon run helloworld.ts",
+      )
     }
     ${blue("denon")} [options]         ${gray("-- eg: denon --help")}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,28 +4,26 @@ import {
   existsSync,
   extname,
   JSON_SCHEMA,
-  log,
   parseYaml,
   readFileStr,
   readJson,
-  writeJson,
   resolve,
   globToRegExp,
 } from "../deps.ts";
 
 import { WatcherConfig } from "./watcher.ts";
 import { RunnerConfig } from "./runner.ts";
-import { LogConfig } from "./log.ts";
+import log, { LogConfig } from "./log.ts";
 
 import { merge } from "./merge.ts";
 import { Args } from "./args.ts";
-import { BRANCH, VERSION } from "../denon.ts";
+import { BRANCH } from "../denon.ts";
 
 const TS_CONFIG = "denon.config.ts";
 
-/**
- * Possible default configuration files.
- */
+const logger = log.prefix("conf");
+
+/** Possible default configuration files. */
 export const configs = [
   "denon",
   "denon.yaml",
@@ -52,9 +50,7 @@ export const reConfig = new RegExp(
     .join("|"), // i know, right
 );
 
-/**
- * The denon configuration format
- */
+/** The denon configuration format */
 // export interface DenonConfig extends RunnerConfig {
 //   [key: string]: any;
 //   watcher?: WatcherConfig;
@@ -64,9 +60,7 @@ export const reConfig = new RegExp(
 
 export type DenonConfig = RunnerConfig & Partial<CompleteDenonConfig>;
 
-/**
- * Parameters are not optional
- */
+/** Parameters are not optional */
 export interface CompleteDenonConfig extends RunnerConfig {
   [key: string]: unknown;
   watcher: WatcherConfig;
@@ -89,9 +83,7 @@ export const DEFAULT_DENON_CONFIG: CompleteDenonConfig = {
   configPath: "",
 };
 
-/**
- * Read YAML config, throws if YAML format is not valid
- */
+/** Read YAML config, throws if YAML format is not valid */
 async function readYaml(file: string): Promise<unknown> {
   const source = await readFileStr(file);
   return parseYaml(source, {
@@ -100,9 +92,7 @@ async function readYaml(file: string): Promise<unknown> {
   });
 }
 
-/**
- * Safe import a TypeScript file
- */
+/** Safe import a TypeScript file */
 async function importConfig(
   file: string,
 ): Promise<Partial<DenonConfig> | undefined> {
@@ -110,14 +100,12 @@ async function importConfig(
     const configRaw = await import(`file://${resolve(file)}`);
     return configRaw.default as Partial<DenonConfig>;
   } catch (error) {
-    log.error(error.message ?? "Error opening ts config config");
+    logger.error(error.message ?? "Error opening ts config config");
     return;
   }
 }
 
-/**
- * Clean config from malformed strings
- */
+/** Clean config from malformed strings */
 function cleanConfig(
   config: Partial<DenonConfig>,
   file?: string,
@@ -133,18 +121,14 @@ function cleanConfig(
   return config;
 }
 
-/**
- * Returns, if exists, the config filename
- */
+/** Returns, if exists, the config filename */
 export function getConfigFilename(): string | undefined {
   return configs.find((filename) => {
     return existsSync(filename) && Deno.statSync(filename).isFile;
   });
 }
 
-/**
- * Reads the denon config from a file
- */
+/** Reads the denon config from a file */
 export async function readConfig(
   file: string | undefined = getConfigFilename(),
 ): Promise<CompleteDenonConfig> {
@@ -192,44 +176,42 @@ export async function readConfig(
           }
         }
       } catch {
-        log.warning(`unsupported configuration \`${file}\``);
+        logger.warning(`unsupported configuration \`${file}\``);
       }
     }
   }
   return config;
 }
 
-/**
- * Reads the denon config from a file
- */
+/** Reads the denon config from a file */
 export async function writeConfigTemplate(template: string): Promise<void> {
   const templates = `https://deno.land/x/denon@${BRANCH}/templates`;
   const url = `${templates}/${template}`;
-  log.info(`fetching template from ${url}`);
+  logger.info(`fetching template from ${url}`);
 
   let res;
   try {
     res = await fetch(url);
   } catch (e) {
-    log.error(`${url} cannot be fetched`);
+    logger.error(`${url} cannot be fetched`);
   }
 
   if (res) {
     if (res.status === 200) {
       try {
-        log.info(`writing template to \`${template}\``);
+        logger.info(`writing template to \`${template}\``);
         await Deno.writeTextFile(
           resolve(Deno.cwd(), template),
           await res.text(),
         );
-        log.info(`\`${template}\` created in current working directory`);
+        logger.info(`\`${template}\` created in current working directory`);
       } catch (e) {
-        log.error(
+        logger.error(
           `\`${template}\` cannot be saved in current working directory`,
         );
       }
     } else {
-      log.error(
+      logger.error(
         `\`${template}\` is not a denon template. All templates are available on ${templates}/`,
       );
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -202,7 +202,7 @@ export async function readConfig(
 /**
  * Reads the denon config from a file
  */
-export async function writeConfigTemplate(template: string) {
+export async function writeConfigTemplate(template: string): Promise<void> {
   const templates = `https://deno.land/x/denon@${BRANCH}/templates`;
   const url = `${templates}/${template}`;
   log.info(`fetching template from ${url}`);

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-present the denosaurs team. All rights reserved. MIT license.
 
 // deno-lint-ignore-file
+export type Indexable = Record<string, any>;
 
 /**
  * Performs a deep merge of `source` into `target`.
@@ -8,13 +9,13 @@
  */
 export function merge<T extends Record<string, any>>(
   target: T,
-  source: any,
+  source: Indexable,
 ): T {
-  const t = target as Record<string, any>;
-  const isObject = (obj: any) => obj && typeof obj === "object";
+  const t = target as Record<string, unknown>;
+  const isObject = (obj: unknown) => obj && typeof obj === "object";
 
   if (!isObject(target) || !isObject(source)) {
-    return source;
+    return source as T;
   }
 
   for (const key of Object.keys(source)) {
@@ -24,7 +25,7 @@ export function merge<T extends Record<string, any>>(
     if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
       t[key] = sourceValue;
     } else if (isObject(targetValue) && isObject(sourceValue)) {
-      t[key] = merge(Object.assign({}, targetValue), sourceValue);
+      t[key] = merge(Object.assign({}, targetValue), sourceValue as Indexable);
     } else {
       t[key] = sourceValue;
     }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -3,10 +3,8 @@
 // deno-lint-ignore-file
 export type Indexable = Record<string, any>;
 
-/**
- * Performs a deep merge of `source` into `target`.
- * Mutates `target` only but not its objects and arrays.
- */
+/** Performs a deep merge of `source` into `target`.
+ * Mutates `target` only but not its objects and arrays. */
 export function merge<T extends Record<string, any>>(
   target: T,
   source: Indexable,

--- a/src/runner_test.ts
+++ b/src/runner_test.ts
@@ -16,21 +16,21 @@ Deno.test({
     };
     const runner = new Runner(config);
 
-    assertEquals(runner.build("oneliner-1").cmd, [
+    assertEquals(runner.build("oneliner-1")[0].cmd, [
       "deno",
       "run",
       "helloworld.ts",
     ]);
-    assertEquals(runner.build("oneliner-2").cmd, [
+    assertEquals(runner.build("oneliner-2")[0].cmd, [
       "deno",
       "test",
       "helloworld.ts",
     ]);
-    assertEquals(runner.build("oneliner-3").cmd, [
+    assertEquals(runner.build("oneliner-3")[0].cmd, [
       "deno",
       "test",
     ]);
-    assertEquals(runner.build("oneliner-4").cmd, [
+    assertEquals(runner.build("oneliner-4")[0].cmd, [
       "sh",
       "build.sh",
     ]);
@@ -50,7 +50,7 @@ Deno.test({
     };
     const runner = new Runner(config);
 
-    assertEquals(runner.build("compact-1").cmd, [
+    assertEquals(runner.build("compact-1")[0].cmd, [
       "deno",
       "run",
       "--allow-all",
@@ -80,18 +80,18 @@ Deno.test({
     };
     const runner = new Runner(config);
 
-    assertEquals(runner.build("extended-1").cmd, [
+    assertEquals(runner.build("extended-1")[0].cmd, [
       "deno",
       "test",
       "--allow-all",
       "helloworld.ts",
     ]);
-    assertEquals(runner.build("extended-2").cmd, [
+    assertEquals(runner.build("extended-2")[0].cmd, [
       "deno",
       "test",
       "--allow-all",
     ]);
-    assertEquals(runner.build("extended-3").cmd, [
+    assertEquals(runner.build("extended-3")[0].cmd, [
       "sh",
       "build.sh",
     ]);

--- a/src/runner_test.ts
+++ b/src/runner_test.ts
@@ -4,7 +4,7 @@ import { RunnerConfig, Runner } from "./runner.ts";
 import { assertEquals } from "../test_deps.ts";
 
 Deno.test({
-  name: "runner:build:oneliner",
+  name: "runner | build | oneliner",
   async fn(): Promise<void> {
     const config: RunnerConfig = {
       scripts: {
@@ -26,19 +26,13 @@ Deno.test({
       "test",
       "helloworld.ts",
     ]);
-    assertEquals(runner.build("oneliner-3")[0].cmd, [
-      "deno",
-      "test",
-    ]);
-    assertEquals(runner.build("oneliner-4")[0].cmd, [
-      "sh",
-      "build.sh",
-    ]);
+    assertEquals(runner.build("oneliner-3")[0].cmd, ["deno", "test"]);
+    assertEquals(runner.build("oneliner-4")[0].cmd, ["sh", "build.sh"]);
   },
 });
 
 Deno.test({
-  name: "runner:build:compact",
+  name: "runner | build | compact",
   async fn(): Promise<void> {
     const config: RunnerConfig = {
       scripts: {
@@ -60,7 +54,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "runner:build:extended",
+  name: "runner | build | extended",
   async fn(): Promise<void> {
     const config: RunnerConfig = {
       scripts: {
@@ -91,9 +85,6 @@ Deno.test({
       "test",
       "--allow-all",
     ]);
-    assertEquals(runner.build("extended-3")[0].cmd, [
-      "sh",
-      "build.sh",
-    ]);
+    assertEquals(runner.build("extended-3")[0].cmd, ["sh", "build.sh"]);
   },
 });

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -9,6 +9,12 @@ export interface Scripts {
 }
 
 /**
+ * A collection of runnable scripts.
+ * See Script
+ */
+export type ScriptArray = (string | ScriptObject)[];
+
+/**
  * A runnable script.
  * Can be as simple as a string:
  * ```json
@@ -27,7 +33,7 @@ export interface Scripts {
  * }
  * ```
  */
-export type Script = string | ScriptObject;
+export type Script = string | ScriptObject | ScriptArray;
 
 /**
  * Most complete representation of a script. Can

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -1,21 +1,16 @@
 // Copyright 2020-present the denosaurs team. All rights reserved. MIT license.
 
-/**
- * Map of declared scripts,
- * Used by `Runner`.
- */
+/** Map of declared scripts,
+ * Used by `Runner`. */
 export interface Scripts {
   [key: string]: Script;
 }
 
-/**
- * A collection of runnable scripts.
- * See Script
- */
+/** A collection of runnable scripts.
+ * See Script */
 export type ScriptArray = (string | ScriptObject)[];
 
-/**
- * A runnable script.
+/** A runnable script.
  * Can be as simple as a string:
  * ```json
  * {
@@ -31,119 +26,88 @@ export type ScriptArray = (string | ScriptObject)[];
  *      "allow": [ "env", "read" ]
  *   }
  * }
- * ```
- */
+ * ``` */
 export type Script = string | ScriptObject | ScriptArray;
 
-/**
- * Most complete representation of a script. Can
+/** Most complete representation of a script. Can
  * be configured in details as it extends `ScriptOptions`
  * and can also contain a `desc` that is displayed along
- * script name when`denon` is run without any arguments .
- */
+ * script name when`denon` is run without any arguments . */
 export interface ScriptObject extends ScriptOptions {
   cmd: string;
   desc?: string;
 }
 
-/**
- * Deno CLI flags in a map.
- * `{ allow: [ run, env ]}` -> `[--allow-run, --allow-env]`
- */
+/** Deno CLI flags in a map.
+ * `{ allow: { "write": "/tmp", "read": "/tmp" }}`
+ * -> `[--allow-write=/tmp, --allow-read=/tmp]` */
 export interface FlagsObject {
   [key: string]: unknown;
 }
 
-/**
- * Environment variables in a map.
- * `{ TOKEN: "SECRET!" }` -> `TOKEN=SECRET`
- */
+/** Environment variables in a map.
+ * `{ TOKEN: "SECRET!" }`
+ * -> `TOKEN=SECRET` */
 export interface EnvironmentVariables {
   [key: string]: string;
 }
 
-/**
- * Additional script options.
+/** Additional script options.
  *
  * These can be applied both in `ScriptObject`s and at top-level
- * in which case they're applied to all the scripts defined in the file
- */
+ * in which case they're applied to all the scripts defined in the file */
 export interface ScriptOptions {
-  /**
-   * A map of environment variables to be passed to the script
-   */
+  /** A map of environment variables to be passed to the script */
   env?: EnvironmentVariables;
-  /**
-   * A list of boolean `--allow-*` deno cli options or
-   * a map of option names to values
-   */
-  allow?: string[] | FlagsObject;
-  /**
-   * The path to an importmap json file,
+  /** A list of boolean `--allow-*` deno cli options or
+   * a map of option names to values */
+  allow?: string[] | FlagsObject | "all";
+  /** The path to an importmap json file,
    * passed to deno cli's `--importmap` option.
    *
-   * **Note** This currently requires the `--unstable` flag
-   */
+   * **Note** This currently requires the `--unstable` flag */
   importmap?: string;
-  /**
-   * The path to a tsconfig json file,
-   * passed to deno cli's `--tsconfig` option.
-   */
+  /** The path to a tsconfig json file,
+   * passed to deno cli's `--tsconfig` option. */
   tsconfig?: string;
-  /**
-   * If the code that has to be run is using unstable features
+  /** If the code that has to be run is using unstable features
    * from deno standard library this option should be set to
-   * `true` so that `--unstable` option is passed to deno cli's.
-   */
+   * `true` so that `--unstable` option is passed to deno cli's. */
   unstable?: boolean;
-  /**
-   * The hostname and port where to start the inspector,
-   * passed to deno cli's `--inspect` option.
-   */
+  /** The hostname and port where to start the inspector,
+   * passed to deno cli's `--inspect` option. */
   inspect?: string;
-  /**
-   * Same as `inspect`, but breaks at start of user script.
-   */
+  /** Same as `inspect`, but breaks at start of user script. */
   inspectBrk?: string;
-  /**
-   * The path to an _existing_ lockfile,
+  /** The path to an _existing_ lockfile,
    * passed to deno cli's `--lock` option.
    *
    * **Note** This doesn't create the lockfile, use `--lock-write` manually
-   * when appropriate
-   */
+   * when appropriate */
   lock?: string;
-  /**
-   * The path to a PEM certificate file,
-   * passed to deno cli's `--cert` option.
-   */
+  /** The path to a PEM certificate file,
+   * passed to deno cli's `--cert` option. */
   cert?: string;
-  /**
-   * The log level, passed to deno cli's `--log-level` option.
-   */
+  /** The log level, passed to deno cli's `--log-level` option. */
   log?: string;
-  /**
-   * Should watch. Enabled by default. Toggle file watching
-   * for particular script.
-   */
+  /** Should watch. Enabled by default. Toggle file watching
+   * for particular script. */
   watch?: boolean;
-  /**
-   * Standard i/o/err, to be passed directly to Deno.run.
-   */
+  /** Standard i/o/err, to be passed directly to Deno.run. */
   stdin?: "inherit" | "piped" | "null" | number;
   stdout?: "inherit" | "piped" | "null" | number;
   stderr?: "inherit" | "piped" | "null" | number;
 }
 
-/**
- * Build deno flags from ScriptOptions.
- * `{ allow: [ run, env ]}` -> `[--allow-run, --allow-env]`
- */
+/** Build deno flags from ScriptOptions.
+ * `{ allow: [ run, env ]}` -> `[--allow-run, --allow-env]` */
 export function buildFlags(options: ScriptOptions): string[] {
   let flags: string[] = [];
   if (options.allow) {
     if (Array.isArray(options.allow)) {
       options.allow.forEach((flag) => flags.push(`--allow-${flag}`));
+    } else if (options.allow === "all") {
+      flags.push(`--allow-all`);
     } else if (typeof options.allow === "object") {
       Object.entries(options.allow).map(([flag, value]) => {
         if (!value || (typeof value === "boolean" && value)) {

--- a/src/scripts_test.ts
+++ b/src/scripts_test.ts
@@ -4,15 +4,11 @@ import { buildFlags, ScriptOptions } from "./scripts.ts";
 import { assert, assertEquals } from "../test_deps.ts";
 
 Deno.test({
-  name: "scripts:flags",
+  name: "scripts | flags",
   fn: () => {
     const options: ScriptOptions = {
       watch: false, // not going to show up
-      allow: [
-        "net",
-        "env",
-        "write",
-      ],
+      allow: ["net", "env", "write"],
       cert: "secure.pem",
       env: {
         SECRET: "123", // not going to show up
@@ -55,8 +51,9 @@ Deno.test({
       len--;
     };
 
-    ["--watch", "--env", "--stderr", "--stdin", "--stdout"]
-      .forEach((_) => noExist(_));
+    ["--watch", "--env", "--stderr", "--stdin", "--stdout"].forEach((_) =>
+      noExist(_)
+    );
 
     [
       "--allow-net",
@@ -65,8 +62,7 @@ Deno.test({
       "--unstable",
       "--inspect=127.0.0.1:4321",
       "--inspect-brk=127.0.0.1:1234",
-    ]
-      .forEach((_) => exist(_));
+    ].forEach((_) => exist(_));
 
     const values = {
       "--cert": "secure.pem",

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -69,7 +69,7 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
     this.reload();
   }
 
-  reload() {
+  reload(): void {
     this.#watch = this.#config.legacy ? this.legacyWatch : this.denoWatch;
     if (this.#config.paths) {
       this.#paths = this.#config.paths;
@@ -117,7 +117,7 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
     return true;
   }
 
-  private reset() {
+  private reset(): void {
     this.#changes = {};
     this.#signal = deferred();
   }
@@ -148,7 +148,7 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
     return this.iterate();
   }
 
-  private async denoWatch() {
+  private async denoWatch(): Promise<void> {
     let timer = 0;
     const debounce = () => {
       clearTimeout(timer);
@@ -176,7 +176,7 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
     }
   }
 
-  private async legacyWatch() {
+  private async legacyWatch(): Promise<void> {
     let timer = 0;
     const debounce = () => {
       clearTimeout(timer);

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -1,7 +1,6 @@
 // Copyright 2020-present the denosaurs team. All rights reserved. MIT license.
 
 import {
-  log,
   deferred,
   globToRegExp,
   extname,
@@ -10,16 +9,13 @@ import {
   delay,
 } from "../deps.ts";
 
-/**
- * Represents a change in the filesystem.
- * Should reflect the Deno.FsEvent.
- */
-type FileAction =
-  | "any"
-  | "access"
-  | "create"
-  | "modify"
-  | "remove";
+import log from "./log.ts";
+
+const logger = log.prefix("path");
+
+/** Represents a change in the filesystem.
+ * Should reflect the Deno.FsEvent. */
+type FileAction = "any" | "access" | "create" | "modify" | "remove";
 
 /** A file that was changed, created or removed */
 export interface FileEvent {
@@ -45,14 +41,12 @@ export interface WatcherConfig {
   legacy?: boolean;
 }
 
-/**
- * Watches for file changes in `paths` path
+/** Watches for file changes in `paths` path
  * yielding an array of all of the changes
  * each time one or more changes are detected.
  * It is debounced by `interval`, `recursive`, `exts`,
  * `match` and `skip` are filtering the files which
- * will yield a change
- */
+ * will yield a change */
 export class Watcher implements AsyncIterable<FileEvent[]> {
   #signal = deferred();
   #changes: { [key: string]: FileAction[] } = {};
@@ -97,23 +91,26 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
   isWatched(path: string): boolean {
     path = this.verifyPath(path);
     if (
-      extname(path) && this.#exts?.length &&
+      extname(path) &&
+      this.#exts?.length &&
       this.#exts?.every((ext) => !path.endsWith(ext))
     ) {
-      log.debug(`path ${path} does not have right extension`);
+      logger.debug(`path ${path} does not have right extension`);
       return false;
     } else if (
-      this.#skip?.length && this.#skip?.some((skip) => path.match(skip))
+      this.#skip?.length &&
+      this.#skip?.some((skip) => path.match(skip))
     ) {
-      log.debug(`path ${path} is skipped`);
+      logger.debug(`path ${path} is skipped`);
       return false;
     } else if (
-      this.#match?.length && this.#match?.every((match) => !path.match(match))
+      this.#match?.length &&
+      this.#match?.every((match) => !path.match(match))
     ) {
-      log.debug(`path ${path} is not matched`);
+      logger.debug(`path ${path} is not matched`);
       return false;
     }
-    log.debug(`path ${path} is matched`);
+    logger.debug(`path ${path} is matched`);
     return true;
   }
 
@@ -136,10 +133,10 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
     this.#watch();
     while (true) {
       await this.#signal;
-      yield Object.entries(this.#changes).map(([
+      yield Object.entries(this.#changes).map(([path, type]) => ({
         path,
         type,
-      ]) => ({ path, type }));
+      }));
       this.reset();
     }
   }
@@ -156,9 +153,7 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
     };
 
     const run = async () => {
-      for await (
-        const event of Deno.watchFs(this.#paths)
-      ) {
+      for await (const event of Deno.watchFs(this.#paths)) {
         const { kind, paths } = event;
         for (const path of paths) {
           if (this.isWatched(path)) {
@@ -214,11 +209,7 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
         const post = current[path];
         if (pre && !post) {
           this.#changes[path].push("remove");
-        } else if (
-          pre &&
-          post &&
-          pre.getTime() !== post.getTime()
-        ) {
+        } else if (pre && post && pre.getTime() !== post.getTime()) {
           this.#changes[path].push("modify");
         }
       }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -208,14 +208,17 @@ export class Watcher implements AsyncIterable<FileEvent[]> {
         const pre = previous[path];
         const post = current[path];
         if (pre && !post) {
+          if (!this.#changes[path]) this.#changes[path] = [];
           this.#changes[path].push("remove");
         } else if (pre && post && pre.getTime() !== post.getTime()) {
+          if (!this.#changes[path]) this.#changes[path] = [];
           this.#changes[path].push("modify");
         }
       }
 
       for (const path in current) {
         if (!previous[path] && current[path]) {
+          if (!this.#changes[path]) this.#changes[path] = [];
           this.#changes[path].push("create");
         }
       }

--- a/src/watcher_test.ts
+++ b/src/watcher_test.ts
@@ -3,12 +3,10 @@
 import { assert } from "../test_deps.ts";
 
 import { Watcher, WatcherConfig } from "./watcher.ts";
-import { setupLog } from "./log.ts";
 
 Deno.test({
-  name: "watcher:exts",
+  name: "watcher | exts",
   async fn(): Promise<void> {
-    await setupLog();
     const config: WatcherConfig = {
       paths: [Deno.cwd()],
       interval: 350,
@@ -52,9 +50,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "watcher:skip",
+  name: "watcher | skip",
   async fn(): Promise<void> {
-    await setupLog();
     const config: WatcherConfig = {
       paths: [Deno.cwd()],
       interval: 350,


### PR DESCRIPTION
Adds the ability to run more than one script before starting the daemon. Closes #50 

Needs to be tested on `windows` and on `linux`. 

Other fixes include:
-  legacy watcher, related to #73 
-  structured logger