### PR TITLE
fix: typescript export notation for DenonConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ scripts:
 Denon configuration can be provided as a `.config.ts` file:
 
 ```typescript
-import { DenonConfig } from "https://deno.land/x/denon/mod.ts";
+import type { DenonConfig } from "https://deno.land/x/denon/mod.ts";
 
 const config: DenonConfig = {
   scripts: {

--- a/mod.ts
+++ b/mod.ts
@@ -4,4 +4,5 @@ export * from "./denon.ts";
 export * from "./src/watcher.ts";
 export * from "./src/runner.ts";
 
-export { DenonConfig, DEFAULT_DENON_CONFIG } from "./src/config.ts";
+export { DEFAULT_DENON_CONFIG } from "./src/config.ts";
+export type { DenonConfig } from "./src/config.ts";


### PR DESCRIPTION
When using the typescript config file in the README, the following errors occur:
`This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.`

`Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
export { DenonConfig, DEFAULT_DENON_CONFIG } from "./src/config.ts";`

Both are resolved by specifying the import/exports as type only