### PR TITLE
revert fix for #102

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -159,11 +159,6 @@ export class Runner {
   /** Create an `Execution` object to handle the lifetime
    * of the process that is executed. */
   execute(command: Command): Deno.Process {
-    // Fix for #102
-    if (Deno.build.os === "windows") {
-      command.cmd = ["cmd", "/c"].concat(command.cmd);
-    }
-
     const options = {
       cmd: command.cmd,
       env: command.options.env ?? {},


### PR DESCRIPTION
prepending cmd /c prevents denon from properly closing deno processes