### PR TITLE
fix: get the correct option

### DIFF
--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -1,0 +1,77 @@
+// Copyright 2020-present the denosaurs team. All rights reserved. MIT license.
+
+import { parseArgs } from "./args.ts";
+import { assertEquals } from "../test_deps.ts";
+
+Deno.test({
+  name: "args | parseArgs | option",
+  fn: () => {
+    assertEquals(parseArgs(["--cfg", "config.json"]), {
+      cmd: [],
+      config: "config.json",
+      help: false,
+      init: undefined,
+      upgrade: undefined,
+      version: false,
+    });
+    assertEquals(
+      parseArgs(
+        [
+          "run",
+          "-A",
+          "--config",
+          "tsconfig.json",
+          "--cfg",
+          "config.json",
+          "mod.ts",
+        ],
+      ),
+      {
+        cmd: ["run", "-A", "--config", "tsconfig.json", "mod.ts"],
+        config: "config.json",
+        help: false,
+        init: undefined,
+        upgrade: undefined,
+        version: false,
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "args | parseArgs | option | upgrade",
+  fn: () => {
+    assertEquals(parseArgs(["--upgrade", "latest"]), {
+      cmd: [],
+      config: undefined,
+      help: false,
+      init: undefined,
+      upgrade: "latest",
+      version: false,
+    });
+    assertEquals(parseArgs(["--upgrade"]), {
+      cmd: [],
+      config: undefined,
+      help: false,
+      init: undefined,
+      upgrade: "latest",
+      version: false,
+    });
+    assertEquals(parseArgs(["--upgrade", "2.4.5"]), {
+      cmd: [],
+      config: undefined,
+      help: false,
+      init: undefined,
+      upgrade: "v2.4.5",
+      version: false,
+    });
+    assertEquals(parseArgs(["--upgrade", "v2.4.5"]), {
+      cmd: [],
+      config: undefined,
+      help: false,
+      init: undefined,
+      upgrade: "v2.4.5",
+      version: false,
+    });
+  },
+});

--- a/src/args.ts
+++ b/src/args.ts
@@ -32,50 +32,48 @@ export function parseArgs(args: string[] = Deno.args): Args {
     cmd: [],
   };
 
-  if ((args.includes("--config") || args.includes("-c")) && args.length > 1) {
-    flags.config = args[1];
-    args = args.slice(2);
-  }
-
-  if (args.includes("--help") || args.includes("-h")) {
-    flags.help = true;
-    args = args.slice(1);
-  }
-
-  if (args.includes("--version") || args.includes("-v")) {
-    flags.version = true;
-    args = args.slice(1);
-  }
-
-  if (args.includes("--init") || args.includes("-i")) {
-    const index = args.includes("--init")
-      ? args.indexOf("--init")
-      : args.indexOf("-i");
-    const next = args[index + 1];
-
-    if (next) {
-      flags.init = next;
-      args = args.slice(2);
-    } else {
-      flags.init = "json";
-      args = args.slice(1);
+  const indexOf = (...flags: string[]) => {
+    for (const flag of flags) {
+      const i = args.indexOf(flag);
+      if (i >= 0) {
+        return i;
+      }
     }
+    return -1;
+  };
+
+  const indexConfig = indexOf("--cfg");
+  if (indexConfig >= 0) {
+    flags.config = args.splice(indexConfig, 2)[1];
   }
 
-  if (args.includes("--upgrade") || args.includes("-u")) {
-    const index = args.includes("--upgrade")
-      ? args.indexOf("--upgrade")
-      : args.indexOf("-u");
-    const next = args[index + 1];
+  const indexHelp = indexOf("--help", "-h");
+  if (indexHelp >= 0) {
+    flags.help = true;
+    args.splice(indexHelp, 1);
+  }
 
-    if (next && (next === "latest" || reVersion.test(next))) {
-      flags.upgrade = !next.startsWith("v") || next !== "latest"
-        ? "v" + next
-        : next;
-      args = args.slice(2);
+  const indexVersion = indexOf("--version", "-v");
+  if (indexVersion >= 0) {
+    flags.version = true;
+    args.splice(indexVersion, 1);
+  }
+
+  const indexInit = indexOf("--init", "-i");
+  if (indexInit >= 0) {
+    const [, next] = args.splice(indexInit, 2);
+
+    flags.init = next || "json";
+  }
+
+  const indexUpgrade = indexOf("--upgrade", "-u");
+  if (indexUpgrade >= 0) {
+    const [, next] = args.splice(indexUpgrade, 2);
+
+    if (next && (next !== "latest" || reVersion.test(next))) {
+      flags.upgrade = !next.startsWith("v") ? "v" + next : next;
     } else {
       flags.upgrade = "latest";
-      args = args.slice(1);
     }
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -222,7 +222,7 @@ Options:
     -v --version            Show version.
     -i --init               Create config file in current working dir.
     -u --upgrade <version>  Upgrade to latest version. (default: master)
-    -c --config <file>      Use specific file as configuration.
+       --cfg <file>      Use specific file as configuration.
 `,
   );
 }


### PR DESCRIPTION
Relate #92 

 - Remove exactly option in `args` instead of `args[0]` (use `Array.protpty.splice` to remove)
 - Chang option `--config`, '-c' to `--cfg` (conflict option with deno)
 - Fixed wrong version for `--upgrade`: `--upgrade latest` become `latest` instead of `vlates`


Old `parseArgs(["--cfg", "config.json"])`:
![image](https://user-images.githubusercontent.com/19208123/101378824-263b8300-38e6-11eb-8e3e-b9e5395705fc.png)

Old `parseArgs(["--upgrade", "latest"])`:
![image](https://user-images.githubusercontent.com/19208123/101378934-453a1500-38e6-11eb-8da1-0732818bc549.png)

Test #92: `deno install -n denon2 -qAf --unstable https://raw.githubusercontent.com/hong4rc/denon/option/denon.ts`

and call `denon2 run -A --config tsconfig.json main.ts`

and got:
> [!] [#0] starting `--config tsconfig.json main.ts`
