### PR TITLE
chore: implicitly using latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ To install denon simply enter the following into a terminal:
 ### deno.land
 
 ```bash
-deno install -qAf --unstable https://deno.land/x/denon@2.4.4/denon.ts
+deno install -qAf --unstable https://deno.land/x/denon/denon.ts
 ```
 
 ### nest.land
 
 ```bash
-deno install -qAf --unstable https://x.nest.land/denon@2.4.4/denon.ts
+deno install -qAf --unstable https://x.nest.land/denon/denon.ts
 ```
 
 > ⚠️ Make sure you are using `deno` version `^1.4.0` to install this executable. You can upgrade running `deno upgrade`.


### PR DESCRIPTION
User can easily install the latest `denon` version, we don't need to change the version in the readme

![image](https://user-images.githubusercontent.com/19208123/101510085-0bcbdd00-39ac-11eb-8758-631ad41f89ed.png)
