### PR TITLE
fix/issue-49: On windows, kill process instead of closing

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -90,6 +90,7 @@ export class Daemon implements AsyncIterable<DenonEvent> {
       if (Deno.build.os === "windows") {
         logger.debug(`closing (windows) process with pid ${p.pid}`);
         p.kill(9);
+        p.close();
       } else {
         logger.debug(`killing (unix) process with pid ${p.pid}`);
         p.kill(9);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -89,7 +89,7 @@ export class Daemon implements AsyncIterable<DenonEvent> {
       const p = pcopy[id];
       if (Deno.build.os === "windows") {
         logger.debug(`closing (windows) process with pid ${p.pid}`);
-        p.close();
+        p.kill(9);
       } else {
         logger.debug(`killing (unix) process with pid ${p.pid}`);
         p.kill(9);


### PR DESCRIPTION
Implemented @dale-roberts suggestion. Tested with deno 1.6.3 and denon 2.4.5.