### PR TITLE
fix(#144): Deno 1.16 support

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -144,7 +144,7 @@ export class Daemon implements AsyncIterable<DenonEvent> {
     }
   }
 
-  private async onExit(): Promise<void> {
+  private onExit(): void {
     if (Deno.build.os !== "windows") {
       const signs: Deno.Signal[] = [
         "SIGHUP",
@@ -152,13 +152,12 @@ export class Daemon implements AsyncIterable<DenonEvent> {
         "SIGTERM",
         "SIGTSTP",
       ];
-      await Promise.all(signs.map((s) => {
-        (async () => {
-          await Deno.signal(s);
+      signs.map((s) => {
+        Deno.addSignalListener(s, () => {
           this.killAll();
           Deno.exit(0);
-        })();
-      }));
+        });
+      });
     }
   }
 


### PR DESCRIPTION
Fix #144 

Changed from `Deno.signal` to use `Deno.addSignalListener`.

I didn't understand why I surrounded this part with `Promise.all`, but I changed it to a synchronization function because I thought it was unnecessary by `addSignalListener`.