### PR TITLE
fix(#126): replace `SIGKILL` with `SIGTERM`

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -89,11 +89,11 @@ export class Daemon implements AsyncIterable<DenonEvent> {
       const p = pcopy[id];
       if (Deno.build.os === "windows") {
         logger.debug(`closing (windows) process with pid ${p.pid}`);
-        p.kill("SIGKILL");
+        p.kill("SIGTERM");
         p.close();
       } else {
         logger.debug(`killing (unix) process with pid ${p.pid}`);
-        p.kill("SIGKILL");
+        p.kill("SIGTERM");
       }
     }
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -144,7 +144,7 @@ export class Daemon implements AsyncIterable<DenonEvent> {
     }
   }
 
-  private async onExit(): Promise<void> {
+  private onExit(): void {
     if (Deno.build.os !== "windows") {
       const signs: Deno.Signal[] = [
         "SIGHUP",
@@ -152,13 +152,12 @@ export class Daemon implements AsyncIterable<DenonEvent> {
         "SIGTERM",
         "SIGTSTP",
       ];
-      await Promise.all(signs.map((s) => {
-        (async () => {
-          await Deno.signal(s);
+      signs.map((s) => {
+        Deno.addSignalListener(s, () => {
           this.killAll();
           Deno.exit(0);
-        })();
-      }));
+        });
+      });
     }
   }
 


### PR DESCRIPTION
I did this mainly because I agree with OP of #126 in general.