### PR TITLE
feat: allow scripts.ts and scripts.js

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -153,7 +153,7 @@ export async function readConfig(
   config.watcher.paths.push(Deno.cwd());
 
   if (file) {
-    if (file.endsWith("config.js") || file.endsWith("config.ts")) {
+    if (file.endsWith(".js") || file.endsWith(".ts")) {
       const parsed = await importConfig(file);
       if (parsed) {
         config = merge(

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,9 @@ export const configs = [
   "scripts.config.ts",
   "denon.config.js",
   "scripts.config.js",
+
+  "scripts.ts",
+  "scripts.js",
 ];
 
 export const reConfig = new RegExp(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -89,11 +89,11 @@ export class Daemon implements AsyncIterable<DenonEvent> {
       const p = pcopy[id];
       if (Deno.build.os === "windows") {
         logger.debug(`closing (windows) process with pid ${p.pid}`);
-        p.kill("SIGKILL");
+        p.kill("SIGTERM");
         p.close();
       } else {
         logger.debug(`killing (unix) process with pid ${p.pid}`);
-        p.kill("SIGKILL");
+        p.kill("SIGTERM");
       }
     }
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -144,7 +144,7 @@ export class Daemon implements AsyncIterable<DenonEvent> {
     }
   }
 
-  private async onExit(): Promise<void> {
+  private onExit(): void {
     if (Deno.build.os !== "windows") {
       const signs: Deno.Signal[] = [
         "SIGHUP",
@@ -152,13 +152,12 @@ export class Daemon implements AsyncIterable<DenonEvent> {
         "SIGTERM",
         "SIGTSTP",
       ];
-      await Promise.all(signs.map((s) => {
-        (async () => {
-          await Deno.signal(s);
+      signs.map((s) => {
+        Deno.addSignalListener(s, () => {
           this.killAll();
           Deno.exit(0);
-        })();
-      }));
+        });
+      });
     }
   }
 


### PR DESCRIPTION
Closes #152.

I didn't want to touch anything else like the readme or the templates, since that stuff is a bit more complicated and probably needs some discussion. I think just allowing these filenames is fine for now.