### PR TITLE
fix: add "other" type to FileAction

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -89,11 +89,11 @@ export class Daemon implements AsyncIterable<DenonEvent> {
       const p = pcopy[id];
       if (Deno.build.os === "windows") {
         logger.debug(`closing (windows) process with pid ${p.pid}`);
-        p.kill("SIGKILL");
+        p.kill("SIGTERM");
         p.close();
       } else {
         logger.debug(`killing (unix) process with pid ${p.pid}`);
-        p.kill("SIGKILL");
+        p.kill("SIGTERM");
       }
     }
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -144,7 +144,7 @@ export class Daemon implements AsyncIterable<DenonEvent> {
     }
   }
 
-  private async onExit(): Promise<void> {
+  private onExit(): void {
     if (Deno.build.os !== "windows") {
       const signs: Deno.Signal[] = [
         "SIGHUP",
@@ -152,13 +152,12 @@ export class Daemon implements AsyncIterable<DenonEvent> {
         "SIGTERM",
         "SIGTSTP",
       ];
-      await Promise.all(signs.map((s) => {
-        (async () => {
-          await Deno.signal(s);
+      signs.map((s) => {
+        Deno.addSignalListener(s, () => {
           this.killAll();
           Deno.exit(0);
-        })();
-      }));
+        });
+      });
     }
   }
 

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -6,7 +6,7 @@ const logger = log.create("path");
 
 /** Represents a change in the filesystem.
  * Should reflect the Deno.FsEvent. */
-type FileAction = "any" | "access" | "create" | "modify" | "remove";
+type FileAction = "any" | "access" | "create" | "modify" | "remove" | "other";
 
 /** A file that was changed, created or removed */
 export interface FileEvent {


### PR DESCRIPTION
Deno 1.16.3 just released, which added support for the "other" event type in `FSWatcher` here: https://github.com/denoland/deno/pull/12836

This PR just adds it to `FileAction` as well.

Closes #155.